### PR TITLE
Add utf encoding argument for loading default theme

### DIFF
--- a/src/podium/deck.py
+++ b/src/podium/deck.py
@@ -219,7 +219,7 @@ class SlideDeck:
     def ensure_theme(self):
         if self._impl.theme is None:
             defaultThemeFileName = os.path.join(self.app._impl.resource_path, 'app', 'templates', 'default.css')
-            with open(defaultThemeFileName, 'r') as data:
+            with open(defaultThemeFileName, 'r', encoding='utf8') as data:
                 self._impl.theme = data.read()
 
     def redraw(self, slide=None):


### PR DESCRIPTION
Fixes issue on MacOS where launcing podium from the command line works but launcing from the icon fails due to non-ascii characters in templates/default.css

Possibly also relates to #9 