### PR TITLE
Title windows appropriately

### DIFF
--- a/src/podium/deck.py
+++ b/src/podium/deck.py
@@ -11,7 +11,9 @@ class SlideWindow(toga.Window):
     def __init__(self, deck, master):
         self.deck = deck
         self.master = master
-        super().__init__("Slides" if master else "Notes",
+        name = "Slides" if master else "Notes",
+        super().__init__(name,
+            title="Podium - %s" % name,
             position=(200, 200) if master else (100, 100),
             size=(984 if self.deck.aspect == '16:9' else 738, 576),
             # FIXME: This should be False; but doing so


### PR DESCRIPTION
Existing behaviour: when launching Podium, two windows appear: 

* Slides - "Toga"
* Notes - "Toga"

This PR titles the two windows more appropriately: 

* Slides - "Podium - Slides"
* Notes - "Podium - Notes"

Alternative: If "Podium" and "Podium - Notes" seems more clean, let me know and I'll correct the PR accordingly. 
