### PR TITLE
Avoid SQL autodetection for TOML code blocks

### DIFF
--- a/src/podium/resources/remark.js
+++ b/src/podium/resources/remark.js
@@ -78,6 +78,10 @@ function() {
     var classes = (block.className + ' ' + (block.parentNode ? block.parentNode.className : '')).split(/\s+/);
     classes = classes.map(function(c) {return c.replace(/^language-/, '')});
     for (var i = 0; i < classes.length; i++) {
+      // This bundled highlighter does not know TOML; avoid autodetecting it as SQL.
+      if (classes[i] == 'toml') {
+        return 'no-highlight';
+      }
       if (languages[classes[i]] || classes[i] == 'no-highlight') {
         return classes[i];
       }

--- a/tests/test_highlighting.py
+++ b/tests/test_highlighting.py
@@ -1,0 +1,63 @@
+import shutil
+import subprocess
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REMARK_JS = Path(__file__).parents[1] / "src" / "podium" / "resources" / "remark.js"
+
+
+@unittest.skipUnless(
+    shutil.which("node"),
+    "node is required to exercise bundled remark.js",
+)
+class HighlightingTests(unittest.TestCase):
+    def test_toml_blocks_are_not_autodetected_as_sql(self):
+        script = textwrap.dedent(
+            """
+            const fs = require("fs");
+            global.window = {};
+            global.document = {
+              createElement() {
+                return {type: "", innerHTML: "", firstChild: null};
+              },
+              getElementsByTagName() {
+                return [{firstChild: null, insertBefore() {}}];
+              }
+            };
+
+            eval(fs.readFileSync(process.argv[1], "utf8"));
+
+            const block = {
+              className: "toml",
+              parentNode: {className: ""},
+              childNodes: [{
+                nodeType: 3,
+                nodeValue:
+                  "[[packages.wheels]]\\n" +
+                  "name = \\"demo\\"\\n" +
+                  "upload-time = 1\\n" +
+                  "size = 2\\n"
+              }],
+            };
+
+            window.remark.highlighter.engine.highlightBlock(block, "  ");
+
+            if (block.className !== "toml") {
+              throw new Error(`Unexpected class name: ${block.className}`);
+            }
+            if ((block.innerHTML || "").includes("sql")) {
+              throw new Error(`TOML was highlighted as SQL: ${block.innerHTML}`);
+            }
+            """
+        )
+
+        result = subprocess.run(
+            ["node", "-e", script, str(REMARK_JS)],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)


### PR DESCRIPTION
## Summary

- Prevent `toml` fenced code blocks from falling through to highlight.js autodetection.
- Keep TOML blocks unhighlighted in this bundled highlighter so they are not incorrectly marked as SQL.
- Add a regression test that exercises the bundled `remark.js` highlighter behavior with a TOML block.

Closes #72.

## Verification

- `python3.14 -m unittest tests.test_highlighting` failed before the highlighter guard with `Unexpected class name: toml sql` and passes after it.
- `python3.14 -m unittest discover`
- `git diff --check`
- Node smoke check keeps a TOML code block class as `toml` with no generated SQL markup.

Assisted-by: OpenAI Codex
