### PR TITLE
Add zizmor pre-commit configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,19 @@ updates:
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -7,4 +7,6 @@ on:
 jobs:
   check-pr-template:
     name: Check PR template
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@main
+    permissions:
+      contents: read
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -30,13 +33,13 @@ env:
 jobs:
   pre-commit:
     name: Pre-commit checks
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       pre-commit-source: "--group pre-commit"
 
   towncrier:
     name: Check towncrier
-    uses: beeware/.github/.github/workflows/towncrier-run.yml@main
+    uses: beeware/.github/.github/workflows/towncrier-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       tox-source: "--group tox-uv"
 
@@ -64,9 +67,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          # Nothing in this job pushes, so the token doesn't need to be
+          # persisted in .git/config.
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
@@ -80,7 +86,7 @@ jobs:
           uvx briefcase package --adhoc-sign
 
       - name: Upload artefacts
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: installer-${{ matrix.name }}
           path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
 
   towncrier:
     name: Check towncrier
+    # Mirror the permissions the reusable workflow declares; granting less
+    # than the called workflow requests is rejected at workflow startup.
+    permissions:
+      contents: read
+      pull-requests: write
     uses: beeware/.github/.github/workflows/towncrier-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       tox-source: "--group tox-uv"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
 
   towncrier:
     name: Check towncrier
-    # Mirror the permissions the reusable workflow declares; granting less
-    # than the called workflow requests is rejected at workflow startup.
     permissions:
       contents: read
       pull-requests: write
@@ -75,8 +73,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
-          # Nothing in this job pushes, so the token doesn't need to be
-          # persisted in .git/config.
           persist-credentials: false
 
       - name: Install uv

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   changenote:
     name: Dependabot Change Note
-    # Mirror the permissions the reusable workflow declares; the push itself
-    # is authenticated with BRUTUS_PAT_TOKEN, not the job's GITHUB_TOKEN.
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependabot-changenote.yml
+++ b/.github/workflows/dependabot-changenote.yml
@@ -8,5 +8,11 @@ on:
 jobs:
   changenote:
     name: Dependabot Change Note
-    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@main
-    secrets: inherit
+    # Mirror the permissions the reusable workflow declares; the push itself
+    # is authenticated with BRUTUS_PAT_TOKEN, not the job's GITHUB_TOKEN.
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: beeware/.github/.github/workflows/dependabot-changenote.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    secrets:
+      BRUTUS_PAT_TOKEN: ${{ secrets.BRUTUS_PAT_TOKEN }}

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -11,8 +11,11 @@ jobs:
   add-to-project:
     name: Add issue to BeeWare project
     runs-on: ubuntu-latest
+    # The add-to-project action authenticates with BRUTUS_PAT_TOKEN, so the
+    # job's own GITHUB_TOKEN needs no permissions.
+    permissions: {}
     steps:
-      - uses: actions/add-to-project@v2.0.0
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd  # v2.0.0
         with:
           project-url: https://github.com/orgs/beeware/projects/1
           github-token: ${{ secrets.BRUTUS_PAT_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,7 @@ repos:
   #       # remove toml extra once Python 3.10 is no longer supported
   #       additional_dependencies: [".[toml]"]
   #       args: ["--skip=CODE_OF_CONDUCT.md"]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.27.0
+    hooks:
+      - id: zizmor

--- a/changes/96.misc.md
+++ b/changes/96.misc.md
@@ -1,0 +1,1 @@
+The pre-commit configuration now includes zizmor, and the GitHub Actions workflows pass its audit with actions hash-pinned and least-privilege permissions.


### PR DESCRIPTION
Adds [zizmor](https://docs.zizmor.sh) to the pre-commit pipeline, as requested in #95, and fixes every finding it reports on the existing GitHub Actions configuration. Follows the approach of beeware/.github#378.

## Changes

- **`.pre-commit-config.yaml`**: add the `zizmor` hook (v1.27.0).
- **unpinned-uses**: every action and reusable-workflow reference is pinned to a full commit hash (`actions/checkout` v7.0.0, `actions/upload-artifact` v7.0.1, `actions/add-to-project` v2.0.0, and `beeware/.github` pinned to current `main`, 741cc5a).
- **excessive-permissions**: explicit least-privilege `permissions:` everywhere — `contents: read` for CI and the PR-template check; `permissions: {}` for `new-issue.yml` (it authenticates with `BRUTUS_PAT_TOKEN`, so the job's own `GITHUB_TOKEN` needs nothing); `contents: read` + `pull-requests: write` for the changenote workflow, mirroring what the reusable workflow declares.
- **secrets-inherit**: `dependabot-changenote.yml` passes `BRUTUS_PAT_TOKEN` explicitly instead of `secrets: inherit` (the reusable workflow declares it as a required secret).
- **artipacked**: the CI checkout sets `persist-credentials: false`; nothing in that job pushes.
- **dependabot-cooldown**: 7-day cooldown on all three ecosystems, matching beeware/.github#378 — this also resolves #94.

`zizmor .github/` now reports **no findings**, and `pre-commit run --all-files` passes with the new hook.

Fixes #95
Fixes #94

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Fable 5 (Claude Code)